### PR TITLE
fix: Ensure @electron/remote is included in the packaged app

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
             "package.json",
             "!build/**/*.map",
             "!node_modules",
+            "node_modules/@electron/remote/**/*",
             "node_modules/electron-is-dev/**/*.js",
             "node_modules/electron-window-state/**/*.js",
             "node_modules/jsonfile/**/*.js",


### PR DESCRIPTION
Without this, the packaged app throws errors that say that `@electron/remote` or `@electron/remote/main` cannot be found